### PR TITLE
fix : 도커 네트워크명 불일치 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,11 +56,11 @@ jobs:
             # 최신 이미지 pull
             docker pull ${{ secrets.DOCKER_USERNAME }}/codemate:latest
 
-            # 새 컨테이너 실행 (환경변수는 EC2의 .env 파일 사용)
+            # 새 컨테이너 실행 (docker-compose가 생성한 네트워크명: 디렉토리명_네트워크명)
             docker run -d \
               --name codemate \
               --restart unless-stopped \
-              --network codemate-network \
+              --network ec2-user_codemate-network \
               -p 8080:8080 \
               -e SPRING_PROFILES_ACTIVE=prod \
               --env-file ~/.env \

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ server:
 spring:
   # 로컬 DB 설정
   datasource:
-    url: ${DB_URL:jdbc:mysql://localhost:3306/helper}
+    url: ${DB_URL:jdbc:mysql://localhost:3306/codemate}
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:root}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@
 spring:
   config:
     import: optional:file:.env[.properties]
+  data:
+    redis:
+      repositories:
+        enabled: false
 
   # 프로파일 활성화 (기본값: local)
   profiles:


### PR DESCRIPTION
docker-compose로 네트워크 생성시 "파일명_네트워크명"으로 접두어가 붙음.
ec2-user를 붙여줌으로써 해결

- 로컬용 DB 이름 변경
- 레디스 레포지토리 비활성화 (현재 redistTemplate만 사용)