### PR TITLE
refactor : 로컬용 도커컴포즈 접속허용 IP 로컬호스트로 제한

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       MYSQL_USER: user
       MYSQL_ROOT_HOST: '%'
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     volumes:
       - ./mysql-data:/var/lib/mysql  # MySQL 데이터 영속성
 
@@ -20,7 +20,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
       PMA_HOST: mysql  # MySQL 컨테이너의 이름
     ports:
-      - "18080:80"  # 호스트의 18080 포트를 phpMyAdmin의 80 포트에 매핑
+      - "127.0.0.1:18080:80"  # 호스트의 18080 포트를 phpMyAdmin의 80 포트에 매핑
     depends_on:
       - mysql
 
@@ -29,7 +29,7 @@ services:
     container_name: codemate-redis
     command: ["redis-server", "--appendonly", "yes"]  # AOF로 영속성 확보
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - ./redis-data:/data
     restart: unless-stopped
@@ -39,6 +39,6 @@ services:
     image: redislabs/redisinsight:latest
     container_name: redisinsight-container
     ports:
-      - "18081:8001"
+      - "127.0.0.1:18081:8001"
     depends_on:
       - redis


### PR DESCRIPTION
## 변경 사항 설명
- 로컬구축용 도커컴포즈 IP개방 범위 수정

## 관련 이슈
related to #35 

## 변경 유형
해당하는 항목에 체크해 주세요.
- [ ] 버그 수정 (Bug fix)
- [ ] 새로운 기능 (New feature)
- [ ] 주요 변경 사항 (Breaking change)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 코드 스타일 변경 (Code style update)
- [X] 리팩토링 (Refactoring)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가/업데이트 (Test update)
- [ ] 빌드/배포 관련 (Build/Deploy)
- [ ] 기타 (Other)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 로컬 개발 환경의 데이터베이스, 관리 도구, 캐시 서비스의 포트 바인딩을 localhost로 제한하여 보안을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->