### PR TITLE
feat : 최대 3개 팀만 생성 검증 구현

### DIFF
--- a/src/main/java/com/ryu/studyhelper/common/enums/CustomResponseStatus.java
+++ b/src/main/java/com/ryu/studyhelper/common/enums/CustomResponseStatus.java
@@ -30,6 +30,8 @@ public enum CustomResponseStatus {
     ALREADY_VERIFIED(HttpStatus.CONFLICT.value(), "3006", "이미 인증된 회원입니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "3007", "이미 사용 중인 이메일입니다."),
     ALREADY_TEAM_MEMBER(HttpStatus.CONFLICT.value(), "3008", "이미 팀에 속한 멤버입니다."),
+    TEAM_LEADER_CANNOT_LEAVE(HttpStatus.FORBIDDEN.value(), "3009", "팀 리더는 팀을 탈퇴할 수 없습니다. 리더 양도 또는 팀 해산 기능을 사용해주세요."),
+    TEAM_CREATION_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN.value(), "3010", "최대 3개 팀까지만 생성할 수 있습니다."),
 
     /***
      * 4000: NOT_FOUND

--- a/src/main/java/com/ryu/studyhelper/team/TeamMemberRepository.java
+++ b/src/main/java/com/ryu/studyhelper/team/TeamMemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
@@ -41,4 +42,14 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
      * 특정 멤버가 속한 모든 팀 멤버십 조회
      */
     List<TeamMember> findByMemberId(Long memberId);
+
+    /**
+     * 특정 팀에서 특정 멤버의 팀 멤버십 조회
+     */
+    Optional<TeamMember> findByTeamIdAndMemberId(Long teamId, Long memberId);
+
+    /**
+     * 특정 멤버가 LEADER 역할로 속한 팀의 개수 조회
+     */
+    int countByMemberIdAndRole(Long memberId, TeamRole role);
 }


### PR DESCRIPTION
## 변경 사항 설명
- 유저가 LEADER로 존재하는 팀이 최대3개
- MEMBER 역할은 해당없음

## 관련 이슈
#37 

## 변경 유형
해당하는 항목에 체크해 주세요.
- [ ] 버그 수정 (Bug fix)
- [X] 새로운 기능 (New feature)
- [ ] 주요 변경 사항 (Breaking change)
- [ ] 문서 업데이트 (Documentation update)
- [ ] 코드 스타일 변경 (Code style update)
- [ ] 리팩토링 (Refactoring)
- [ ] 성능 개선 (Performance improvement)
- [ ] 테스트 추가/업데이트 (Test update)
- [ ] 빌드/배포 관련 (Build/Deploy)
- [ ] 기타 (Other)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 팀 리더의 팀 탈퇴 제한 추가: 팀 리더는 리더 양도 또는 팀 해산 기능을 통해서만 팀을 떠날 수 있습니다.
  * 팀 생성 제한 추가: 회원당 최대 3개 팀까지만 생성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->