### PR TITLE
fix : preset난이도 표시안되는 오류 수정

### DIFF
--- a/src/main/java/com/ryu/studyhelper/team/TeamService.java
+++ b/src/main/java/com/ryu/studyhelper/team/TeamService.java
@@ -120,8 +120,8 @@ public class TeamService {
 
         // 커스텀 모드일 때 난이도 범위 유효성 검증
         if (request.problemDifficultyPreset().isCustom()) {
-            if (request.customMinLevel() != null && request.customMaxLevel() != null
-                && request.customMinLevel() > request.customMaxLevel()) {
+            if (request.minProblemLevel() != null && request.maxProblemLevel() != null
+                && request.minProblemLevel() > request.maxProblemLevel()) {
                 throw new CustomException(CustomResponseStatus.INVALID_PROBLEM_LEVEL_RANGE);
             }
         }
@@ -132,8 +132,8 @@ public class TeamService {
         // 추천 난이도 설정 업데이트 (프리셋 방식)
         team.updateProblemDifficultySettings(
                 request.problemDifficultyPreset(),
-                request.customMinLevel(),
-                request.customMaxLevel()
+                request.minProblemLevel(),
+                request.maxProblemLevel()
         );
 
         return TeamRecommendationSettingsResponse.from(team);

--- a/src/main/java/com/ryu/studyhelper/team/dto/TeamRecommendationSettingsRequest.java
+++ b/src/main/java/com/ryu/studyhelper/team/dto/TeamRecommendationSettingsRequest.java
@@ -30,11 +30,11 @@ public record TeamRecommendationSettingsRequest(
         @Min(value = 1, message = "최소 난이도는 1 이상이어야 합니다.")
         @Max(value = 30, message = "최소 난이도는 30 이하여야 합니다.")
         @Schema(description = "커스텀 모드일 때 최소 난이도 (1~30)", example = "1")
-        Integer customMinLevel,
+        Integer minProblemLevel,
 
         @Min(value = 1, message = "최대 난이도는 1 이상이어야 합니다.")
         @Max(value = 30, message = "최대 난이도는 30 이하여야 합니다.")
         @Schema(description = "커스텀 모드일 때 최대 난이도 (1~30)", example = "30")
-        Integer customMaxLevel
+        Integer maxProblemLevel
 
 ) {}

--- a/src/main/java/com/ryu/studyhelper/team/dto/TeamRecommendationSettingsResponse.java
+++ b/src/main/java/com/ryu/studyhelper/team/dto/TeamRecommendationSettingsResponse.java
@@ -14,26 +14,19 @@ public record TeamRecommendationSettingsResponse(
         String teamName,
         boolean isActive,
         List<RecommendationDayOfWeek> recommendationDays, // 월요일부터 일요일까지 순서대로
-        String[] recommendationDayNames, // 한글 요일명
         ProblemDifficultyPreset problemDifficultyPreset,
-        String difficultyDisplayName, // 난이도 프리셋 한글명
-        Integer MinProblemLevel, // 커스텀 모드일 때만 값 있음
-        Integer MaxProblemLevel // 커스텀 모드일 때만 값 있음
+        Integer minProblemLevel, // 커스텀 모드일 때만 값 있음
+        Integer maxProblemLevel // 커스텀 모드일 때만 값 있음
 ) {
     public static TeamRecommendationSettingsResponse from(Team team) {
         List<RecommendationDayOfWeek> days = team.getRecommendationDaysList();
-        String[] dayNames = days.stream()
-                .map(RecommendationDayOfWeek::getKoreanName)
-                .toArray(String[]::new);
 
         return new TeamRecommendationSettingsResponse(
                 team.getId(),
                 team.getName(),
                 team.isRecommendationActive(),
                 days,
-                dayNames,
                 team.getProblemDifficultyPreset(),
-                team.getProblemDifficultyPreset().getDisplayName(),
                 team.getEffectiveMinProblemLevel(),
                 team.getEffectiveMaxProblemLevel()
         );


### PR DESCRIPTION
## 관련 이슈
Closes #45 

## 변경 내용
- preset난이도(쉬움,보통,어려움) 선택시 난이도 표시안되는 오류 수정
  - 원인 : preset일때 DB에 null이 저장됨
  - 해결 : effectiveLevel값을 response에 넘겨줌

## 변경 유형
- [ ] [FEATURE] 기능 구현
- [X] [BUG] 버그 수정
- [ ] [REFACTOR] 리팩토링
- [ ] [CHORE] 설정/의존성
- [ ] [DOCS] 문서

## 스크린샷 (UI 변경 시)
<img width="401" height="253" alt="image" src="https://github.com/user-attachments/assets/c74a8da8-9fac-442e-a861-45f020ea13ab" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 문제 난이도 추천 설정이 실제 적용되는 최소/최대 난이도 값을 기반으로 반영되도록 개선했습니다.
  * 사용자 설정한 난이도 범위가 추천 알고리즘에 정확하게 전달되어 더 일관된 추천을 제공합니다.
  * 설정 반영 과정에서 발생하던 불일치가 해결되어 추천 결과의 신뢰성이 향상되었습니다.

* **변경**
  * 추천 설정 API의 필드명이 변경되어 노출되는 난이도 범위명이 새 이름(minProblemLevel/maxProblemLevel)으로 통합되었습니다.
  * 응답에서 요일 목록 및 난이도 표시 이름은 더 이상 포함되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->