### PR TITLE
fix: 팀원 초대 및 멤버 검색 시 이메일 마스킹 적용

### DIFF
--- a/src/main/java/com/ryu/studyhelper/common/util/MaskingUtils.java
+++ b/src/main/java/com/ryu/studyhelper/common/util/MaskingUtils.java
@@ -1,0 +1,32 @@
+package com.ryu.studyhelper.common.util;
+
+/**
+ * 민감 정보 마스킹 유틸리티
+ */
+public final class MaskingUtils {
+
+    private MaskingUtils() {
+    }
+
+    /**
+     * 이메일 주소를 마스킹합니다.
+     * 예: user@example.com -> u****@example.com
+     *     ab@example.com -> ****@example.com (4자 이하인 경우)
+     */
+    public static String maskEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            return email;
+        }
+
+        String[] parts = email.split("@");
+        String localPart = parts[0];
+        String domain = parts[1];
+
+        if (localPart.length() <= 4) {
+            return "****@" + domain;
+        }
+
+        String visiblePart = localPart.substring(0, localPart.length() - 4);
+        return visiblePart + "****@" + domain;
+    }
+}

--- a/src/main/java/com/ryu/studyhelper/member/dto/response/MemberSearchResponse.java
+++ b/src/main/java/com/ryu/studyhelper/member/dto/response/MemberSearchResponse.java
@@ -1,5 +1,6 @@
 package com.ryu.studyhelper.member.dto.response;
 
+import com.ryu.studyhelper.common.util.MaskingUtils;
 import com.ryu.studyhelper.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -14,7 +15,7 @@ public record MemberSearchResponse(
         @Schema(description = "백준 핸들 인증 여부", example = "true")
         boolean verified,
 
-        @Schema(description = "이메일 주소 (인증된 사용자만)", example = "user@example.com")
+        @Schema(description = "이메일 주소 (마스킹)", example = "user****@example.com")
         String email
 ) {
     public static MemberSearchResponse from(Member member) {
@@ -22,7 +23,7 @@ public record MemberSearchResponse(
                 member.getId(),
                 member.getHandle(),
                 member.isVerified(),
-                member.getEmail()
+                MaskingUtils.maskEmail(member.getEmail())
         );
     }
 }

--- a/src/main/java/com/ryu/studyhelper/team/dto/response/InviteMemberResponse.java
+++ b/src/main/java/com/ryu/studyhelper/team/dto/response/InviteMemberResponse.java
@@ -1,5 +1,6 @@
 package com.ryu.studyhelper.team.dto.response;
 
+import com.ryu.studyhelper.common.util.MaskingUtils;
 import com.ryu.studyhelper.team.domain.TeamMember;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -11,7 +12,7 @@ public record InviteMemberResponse(
         @Schema(description = "팀원 ID", example = "1")
         Long teamMemberId,
 
-        @Schema(description = "초대된 멤버의 이메일", example = "member@example.com")
+        @Schema(description = "초대된 멤버의 이메일 (마스킹)", example = "mem****@example.com")
         String email,
 
         @Schema(description = "초대된 멤버의 handle", example = "codemate")
@@ -23,7 +24,7 @@ public record InviteMemberResponse(
     public static InviteMemberResponse from(TeamMember teamMember) {
         return new InviteMemberResponse(
                 teamMember.getId(),
-                teamMember.getMember().getEmail(),
+                MaskingUtils.maskEmail(teamMember.getMember().getEmail()),
                 teamMember.getMember().getHandle(),
                 teamMember.getTeam().getName()
         );

--- a/src/main/java/com/ryu/studyhelper/team/dto/response/TeamMemberResponse.java
+++ b/src/main/java/com/ryu/studyhelper/team/dto/response/TeamMemberResponse.java
@@ -1,5 +1,6 @@
 package com.ryu.studyhelper.team.dto.response;
 
+import com.ryu.studyhelper.common.util.MaskingUtils;
 import com.ryu.studyhelper.team.domain.TeamMember;
 import com.ryu.studyhelper.team.domain.TeamRole;
 
@@ -14,26 +15,9 @@ public record TeamMemberResponse(
         return new TeamMemberResponse(
                 teamMember.getMember().getId(),
                 teamMember.getMember().getHandle(),
-                maskEmail(teamMember.getMember().getEmail()),
+                MaskingUtils.maskEmail(teamMember.getMember().getEmail()),
                 teamMember.getRole(),
                 teamMember.getMember().getId().equals(currentMemberId)
         );
-    }
-
-    private static String maskEmail(String email) {
-        if (email == null || !email.contains("@")) {
-            return email;
-        }
-
-        String[] parts = email.split("@");
-        String localPart = parts[0];
-        String domain = parts[1];
-
-        if (localPart.length() <= 4) {
-            return "****@" + domain;
-        }
-
-        String visiblePart = localPart.substring(0, localPart.length() - 4);
-        return visiblePart + "****@" + domain;
     }
 }


### PR DESCRIPTION
- MaskingUtils 공통 유틸 추가
- InviteMemberResponse, MemberSearchResponse에 마스킹 적용
- TeamMemberResponse 중복 코드 제거 후 공통 유틸 사용

## 관련 이슈
- Closes #83 

## 변경 내용


## 변경 유형
- [ ] [FEATURE] 기능 구현
- [x] [BUG] 버그 수정
- [x] [REFACTOR] 리팩토링
- [ ] [CHORE] 설정/의존성
- [ ] [DOCS] 문서

## 테스트
- [ ] 테스트 완료

## 스크린샷 (UI 변경 시)
<!-- Before/After 스크린샷 -->

## 참고사항
<!-- 나중에 참고할 사항이 있다면 적어두세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 회원 검색 결과 및 팀 멤버 초대 목록에서 이메일 주소가 마스킹되어 사용자 프라이버시 보호가 강화되었습니다. 이메일의 일부 문자만 표시되고 나머지는 가려집니다.

* **개선 사항**
  * 이메일 마스킹 로직이 통합되어 코드 유지보수성과 일관성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->