### PR TITLE
recommendation: 재시도 배치 LazyInitializationException 수정

### DIFF
--- a/src/main/java/com/ryu/studyhelper/recommendation/mailbuilder/RecommendationMailBuilder.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/mailbuilder/RecommendationMailBuilder.java
@@ -3,7 +3,6 @@ package com.ryu.studyhelper.recommendation.mailbuilder;
 import com.ryu.studyhelper.infrastructure.mail.sender.MailMessage;
 import com.ryu.studyhelper.infrastructure.mail.support.CssInliner;
 import com.ryu.studyhelper.problem.domain.Problem;
-import com.ryu.studyhelper.recommendation.domain.RecommendationProblem;
 import com.ryu.studyhelper.recommendation.domain.member.MemberRecommendation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,9 +36,10 @@ public class RecommendationMailBuilder {
     private String frontendUrl;
 
     /**
-     * MemberRecommendation으로부터 메일 메시지 생성
+     * 메일 메시지 생성
+     * problems는 호출자가 직접 전달 — lazy 로딩에 의존하지 않음
      */
-    public MailMessage build(MemberRecommendation mr) {
+    public MailMessage build(MemberRecommendation mr, List<Problem> problems) {
         String to = mr.getMember().getEmail();
         String date = mr.getRecommendation().getDate().format(DATE_FORMATTER);
         Long teamId = mr.getTeamId();
@@ -47,7 +47,7 @@ public class RecommendationMailBuilder {
         return new MailMessage(
                 to,
                 buildSubject(date),
-                buildHtml(mr, date, teamId)
+                buildHtml(date, teamId, problems)
         );
     }
 
@@ -57,18 +57,17 @@ public class RecommendationMailBuilder {
         return String.format("[CodeMate] 오늘의 미션 문제 (%s)", date);
     }
 
-    private String buildHtml(MemberRecommendation mr, String date, Long teamId) {
+    private String buildHtml(String date, Long teamId, List<Problem> problems) {
         Context context = new Context();
         context.setVariable("subject", buildSubject(date));
         context.setVariable("recommendationDate", date);
         context.setVariable("teamPageUrl", frontendUrl + "/teams/" + teamId);
 
-        List<RecommendationProblem> rps = mr.getRecommendation().getProblems();
-        List<ProblemView> problems = new ArrayList<>();
-        for (int i = 0; i < rps.size(); i++) {
-            problems.add(ProblemView.from(i + 1, rps.get(i).getProblem()));
+        List<ProblemView> problemViews = new ArrayList<>();
+        for (int i = 0; i < problems.size(); i++) {
+            problemViews.add(ProblemView.from(i + 1, problems.get(i)));
         }
-        context.setVariable("problems", problems);
+        context.setVariable("problems", problemViews);
 
         try {
             context.setVariable("logoImage", getBase64EncodedImage("static/images/logo.png"));

--- a/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailService.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailService.java
@@ -1,10 +1,12 @@
 package com.ryu.studyhelper.recommendation.service;
 
 import com.ryu.studyhelper.common.MissionCyclePolicy;
-import com.ryu.studyhelper.recommendation.dto.internal.BatchResult;
 import com.ryu.studyhelper.infrastructure.mail.sender.MailSender;
+import com.ryu.studyhelper.problem.domain.Problem;
+import com.ryu.studyhelper.recommendation.domain.RecommendationProblem;
 import com.ryu.studyhelper.recommendation.domain.member.EmailSendStatus;
 import com.ryu.studyhelper.recommendation.domain.member.MemberRecommendation;
+import com.ryu.studyhelper.recommendation.dto.internal.BatchResult;
 import com.ryu.studyhelper.recommendation.mailbuilder.RecommendationMailBuilder;
 import com.ryu.studyhelper.recommendation.repository.MemberRecommendationRepository;
 import lombok.RequiredArgsConstructor;
@@ -93,15 +95,26 @@ public class RecommendationEmailService {
     }
 
     /**
-     * 수동 추천: 해당 추천의 팀원들에게 이메일 즉시 발송.
+     * 배치 이메일 발송용 — mr에서 problems를 직접 추출 (JOIN FETCH로 로드된 경우에만 호출)
      */
-    public void send(List<MemberRecommendation> memberRecommendations) {
+    private boolean sendEmail(MemberRecommendation mr) {
+        List<Problem> problems = mr.getRecommendation().getProblems().stream()
+                .map(RecommendationProblem::getProblem)
+                .toList();
+        return sendEmail(mr, problems);
+    }
+
+    /**
+     * 수동 추천: 해당 추천의 팀원들에게 이메일 즉시 발송.
+     * problems는 CreationResult에서 직접 전달 — lazy 로딩 없이 사용.
+     */
+    public void send(List<MemberRecommendation> memberRecommendations, List<Problem> problems) {
         for (MemberRecommendation mr : memberRecommendations) {
-            sendEmail(mr);
+            sendEmail(mr, problems);
         }
     }
 
-    private boolean sendEmail(MemberRecommendation mr) {
+    private boolean sendEmail(MemberRecommendation mr, List<Problem> problems) {
         try {
             String email = mr.getMember().getEmail();
             if (email == null || email.isBlank()) {
@@ -111,7 +124,7 @@ public class RecommendationEmailService {
                 return false;
             }
 
-            mailSender.send(recommendationMailBuilder.build(mr));
+            mailSender.send(recommendationMailBuilder.build(mr, problems));
 
             mr.markEmailAsSent();
             memberRecommendationRepository.save(mr);

--- a/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationSaver.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationSaver.java
@@ -88,8 +88,7 @@ class RecommendationSaver {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     List<MemberRecommendation> saveSuccess(Recommendation rec, List<Problem> problems, List<Member> members, Squad squad) {
         for (Problem problem : problems) {
-            RecommendationProblem rp = recommendationProblemRepository.save(RecommendationProblem.create(problem, rec));
-            rec.getProblems().add(rp); // 수동 추천 시 in-memory 동기화 (메일 빌더가 재조회 없이 사용)
+            recommendationProblemRepository.save(RecommendationProblem.create(problem, rec));
         }
         List<MemberRecommendation> memberRecommendations = members.stream()
                 .map(member -> memberRecommendationRepository.save(

--- a/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationService.java
@@ -65,7 +65,7 @@ public class RecommendationService {
                 recommendationCreator.createForSquad(squad, RecommendationType.MANUAL, missionDate)
                         .orElseThrow(() -> new CustomException(CustomResponseStatus.NO_VERIFIED_HANDLE));
 
-        recommendationEmailService.send(result.memberRecommendations());
+        recommendationEmailService.send(result.memberRecommendations(), result.problems());
 
         return RecommendationDetailResponse.from(result.recommendation(), squad.getTeam(), result.problems());
     }

--- a/src/test/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailServiceTest.java
+++ b/src/test/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailServiceTest.java
@@ -71,7 +71,7 @@ class RecommendationEmailServiceTest {
             when(memberRecommendationRepository.findByRecommendationDateAndEmailSendStatus(
                     any(LocalDate.class), eq(EmailSendStatus.PENDING)))
                     .thenReturn(List.of(mr));
-            when(recommendationMailBuilder.build(mr))
+            when(recommendationMailBuilder.build(eq(mr), any()))
                     .thenReturn(new MailMessage("user@test.com", "제목", "<html>"));
 
             // when
@@ -115,8 +115,8 @@ class RecommendationEmailServiceTest {
 
             MailMessage msg1 = new MailMessage("fail@test.com", "제목", "<html>");
             MailMessage msg2 = new MailMessage("success@test.com", "제목", "<html>");
-            when(recommendationMailBuilder.build(mr1)).thenReturn(msg1);
-            when(recommendationMailBuilder.build(mr2)).thenReturn(msg2);
+            when(recommendationMailBuilder.build(eq(mr1), any())).thenReturn(msg1);
+            when(recommendationMailBuilder.build(eq(mr2), any())).thenReturn(msg2);
 
             doThrow(new RuntimeException("SMTP 오류")).when(mailSender).send(msg1);
             doNothing().when(mailSender).send(msg2);
@@ -142,11 +142,11 @@ class RecommendationEmailServiceTest {
             MemberRecommendation mr1 = createMemberRecommendation(1L, "a@test.com");
             MemberRecommendation mr2 = createMemberRecommendation(2L, "b@test.com");
 
-            when(recommendationMailBuilder.build(any()))
+            when(recommendationMailBuilder.build(any(), any()))
                     .thenReturn(new MailMessage("to", "제목", "<html>"));
 
             // when
-            recommendationEmailService.send(List.of(mr1, mr2));
+            recommendationEmailService.send(List.of(mr1, mr2), List.of());
 
             // then
             verify(mailSender, times(2)).send(any(MailMessage.class));
@@ -164,7 +164,7 @@ class RecommendationEmailServiceTest {
             MemberRecommendation mr = createMemberRecommendation(1L, null);
 
             // when
-            recommendationEmailService.send(List.of(mr));
+            recommendationEmailService.send(List.of(mr), List.of());
 
             // then
             assertThat(mr.getEmailSendStatus()).isEqualTo(EmailSendStatus.FAILED);
@@ -178,7 +178,7 @@ class RecommendationEmailServiceTest {
             MemberRecommendation mr = createMemberRecommendation(1L, "  ");
 
             // when
-            recommendationEmailService.send(List.of(mr));
+            recommendationEmailService.send(List.of(mr), List.of());
 
             // then
             assertThat(mr.getEmailSendStatus()).isEqualTo(EmailSendStatus.FAILED);

--- a/src/test/java/com/ryu/studyhelper/recommendation/service/RecommendationSaverTest.java
+++ b/src/test/java/com/ryu/studyhelper/recommendation/service/RecommendationSaverTest.java
@@ -3,7 +3,6 @@ package com.ryu.studyhelper.recommendation.service;
 import com.ryu.studyhelper.member.domain.Member;
 import com.ryu.studyhelper.problem.domain.Problem;
 import com.ryu.studyhelper.recommendation.domain.Recommendation;
-import com.ryu.studyhelper.recommendation.domain.RecommendationProblem;
 import com.ryu.studyhelper.recommendation.domain.RecommendationStatus;
 import com.ryu.studyhelper.recommendation.domain.RecommendationType;
 import com.ryu.studyhelper.recommendation.domain.member.EmailSendStatus;
@@ -33,13 +32,8 @@ import static org.mockito.Mockito.*;
  * RecommendationSaver 단위 테스트
  *
  * 검증 목표:
- * - saveSuccess() 호출 후 rec.getProblems()가 in-memory에서 동기화되는지
+ * - saveSuccess() 호출 후 상태 전이 및 저장 동작
  * - REQUIRES_NEW 메서드가 반환하는 객체의 내부 상태 계약
- *
- * 재발 방지 배경:
- * saveSuccess()가 DB에 RecommendationProblem을 저장했지만 rec.problems 컬렉션에는
- * 추가하지 않아, 수동 추천 직후 메일 빌더가 빈 문제 목록으로 메일을 발송하는 버그가 발생했다.
- * (@Transactional REQUIRES_NEW로 커밋 후 반환된 rec는 detached 상태이므로 lazy load 불가)
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RecommendationSaver 단위 테스트")
@@ -64,68 +58,6 @@ class RecommendationSaverTest {
     @Nested
     @DisplayName("saveSuccess - 성공 저장")
     class SaveSuccess {
-
-        /**
-         * 핵심 회귀 테스트.
-         * saveSuccess() 후 반환된 MemberRecommendation들의 recommendation.getProblems()가
-         * 비어있으면, 메일 빌더가 0개 문제로 메일을 발송하는 버그가 재발한다.
-         */
-        @Test
-        @DisplayName("저장된 문제가 rec.getProblems()에 반영된다 (메일 빌더 in-memory 계약)")
-        void savedProblems_areReflectedInRecProblems() {
-            // given
-            Recommendation rec = createPendingRecommendation();
-            Problem p1 = createProblem(1000L);
-            Problem p2 = createProblem(1001L);
-            List<Problem> problems = List.of(p1, p2);
-
-            Squad squad = createSquad();
-            Member member = createMember(100L, "user@test.com");
-
-            RecommendationProblem rp1 = RecommendationProblem.create(p1, rec);
-            RecommendationProblem rp2 = RecommendationProblem.create(p2, rec);
-            when(recommendationProblemRepository.save(any()))
-                    .thenReturn(rp1, rp2);
-            when(memberRecommendationRepository.save(any()))
-                    .thenAnswer(inv -> inv.getArgument(0));
-            when(recommendationRepository.save(any()))
-                    .thenAnswer(inv -> inv.getArgument(0));
-
-            // when
-            List<MemberRecommendation> result = recommendationSaver.saveSuccess(rec, problems, List.of(member), squad);
-
-            // then: 반환된 MemberRecommendation의 recommendation.problems가 채워져 있어야 한다
-            // (메일 빌더는 mr.getRecommendation().getProblems()로 문제 목록을 읽는다)
-            assertThat(result).hasSize(1);
-            Recommendation recommendation = result.get(0).getRecommendation();
-            assertThat(recommendation.getProblems())
-                    .as("수동 추천 메일 빌더가 읽는 rec.problems가 비어 있으면 0개 문제로 메일이 발송됨")
-                    .hasSize(2);
-        }
-
-        @Test
-        @DisplayName("저장된 문제 수와 rec.getProblems() 크기가 일치한다")
-        void problemCount_matchesSavedCount() {
-            // given
-            Recommendation rec = createPendingRecommendation();
-            List<Problem> problems = List.of(
-                    createProblem(1000L), createProblem(1001L), createProblem(1002L)
-            );
-            Squad squad = createSquad();
-
-            when(recommendationProblemRepository.save(any()))
-                    .thenAnswer(inv -> inv.getArgument(0));
-            when(memberRecommendationRepository.save(any()))
-                    .thenAnswer(inv -> inv.getArgument(0));
-            when(recommendationRepository.save(any()))
-                    .thenAnswer(inv -> inv.getArgument(0));
-
-            // when
-            recommendationSaver.saveSuccess(rec, problems, List.of(createMember(1L, "a@b.com")), squad);
-
-            // then
-            assertThat(rec.getProblems()).hasSize(3);
-        }
 
         @Test
         @DisplayName("성공 저장 후 rec 상태가 SUCCESS로 전이된다")


### PR DESCRIPTION
- RecommendationSaver.saveSuccess()에서 rec.getProblems().add() 제거 DB에서 로드한 Recommendation의 lazy 컬렉션에 세션 밖에서 접근하여 재시도 배치(retryFailed) 실행 시 LazyInitializationException 발생

- RecommendationMailBuilder.build(mr, problems)로 시그니처 변경 lazy 로딩 대신 호출자가 problems를 직접 전달하도록 명시적 계약 강제

- RecommendationEmailService에 수동 추천용 send(mrs, problems) 추가 배치 경로는 JOIN FETCH로 로드된 컬렉션에서 추출, 수동 추천 경로는 CreationResult.problems 직접 전달

- RecommendationService: send(result.memberRecommendations(), result.problems()) 로 변경


## 관련 이슈
- Closes #205 

## 변경 내용


## 변경 유형
- [ ] [FEATURE] 기능 구현
- [x] [BUG] 버그 수정
- [ ] [REFACTOR] 리팩토링
- [ ] [CHORE] 설정/의존성
- [ ] [DOCS] 문서

## 테스트
- [ ] 테스트 완료

## 스크린샷 (UI 변경 시)
<!-- Before/After 스크린샷 -->

## 참고사항
<!-- 나중에 참고할 사항이 있다면 적어두세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 추천 이메일 생성 시 문제 목록을 명시적으로 전달하도록 API 개선
  * 이메일 발송 시스템의 데이터 처리 흐름 최적화

* **Tests**
  * 변경된 API에 맞게 관련 테스트 업데이트
  * 내부 상태 동기화 관련 테스트 제거 및 재구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->