### PR TITLE
태그 최대 선택 개수 10 → 20으로 확대

### DIFF
--- a/src/main/java/com/ryu/studyhelper/team/dto/request/SquadRecommendationSettingsRequest.java
+++ b/src/main/java/com/ryu/studyhelper/team/dto/request/SquadRecommendationSettingsRequest.java
@@ -27,6 +27,6 @@ public record SquadRecommendationSettingsRequest(
         @Max(value = 10, message = "추천 문제 개수는 10 이하여야 합니다.")
         Integer problemCount,
 
-        @Size(max = 10, message = "포함 태그는 최대 10개까지 설정 가능합니다.")
+        @Size(max = 20, message = "포함 태그는 최대 20개까지 설정 가능합니다.")
         List<String> includeTags
 ) {}


### PR DESCRIPTION
## Summary
- 스쿼드 추천 설정에서 알고리즘 태그 최대 선택 개수를 10개에서 20개로 확대

## Test plan
- [ ] 태그 20개 선택 후 추천 설정 저장 정상 동작 확인
- [ ] 태그 21개 이상 요청 시 400 에러 응답 확인

Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 팀 추천 설정에서 포함 가능한 태그의 최대 개수를 10개에서 20개로 증가했습니다. 사용자는 이제 더 많은 태그를 선택하여 맞춤형 팀 추천을 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->