### PR TITLE
[BUG] 이메일 배치 문제 목록 N배 중복 버그 수정

### DIFF
--- a/src/main/java/com/ryu/studyhelper/recommendation/repository/MemberRecommendationRepository.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/repository/MemberRecommendationRepository.java
@@ -39,11 +39,9 @@ public interface MemberRecommendationRepository extends JpaRepository<MemberReco
      * 특정 날짜 + 이메일 발송 상태의 개인 추천 조회
      * 이메일 발송 배치에서 오늘 대상 조회 시 사용
      */
-    @Query("SELECT DISTINCT mr FROM MemberRecommendation mr " +
+    @Query("SELECT mr FROM MemberRecommendation mr " +
             "JOIN FETCH mr.recommendation r " +
             "JOIN FETCH mr.member m " +
-            "LEFT JOIN FETCH r.problems rp " +
-            "LEFT JOIN FETCH rp.problem " +
             "WHERE r.date = :date " +
             "AND mr.emailSendStatus = :status")
     List<MemberRecommendation> findByRecommendationDateAndEmailSendStatus(

--- a/src/main/java/com/ryu/studyhelper/recommendation/repository/RecommendationProblemRepository.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/repository/RecommendationProblemRepository.java
@@ -27,6 +27,7 @@ public interface RecommendationProblemRepository extends JpaRepository<Recommend
      * @return 문제 목록 (삽입 순서)
      */
     @Query("SELECT rp FROM RecommendationProblem rp " +
+            "JOIN FETCH rp.problem " +
             "WHERE rp.recommendation.id = :recommendationId " +
             "ORDER BY rp.id ASC")
     List<RecommendationProblem> findByRecommendationIdOrderById(@Param("recommendationId") Long recommendationId);

--- a/src/main/java/com/ryu/studyhelper/recommendation/repository/RecommendationProblemRepository.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/repository/RecommendationProblemRepository.java
@@ -21,11 +21,10 @@ import java.util.List;
 public interface RecommendationProblemRepository extends JpaRepository<RecommendationProblem, Long> {
 
     /**
-     * 특정 추천의 문제들을 순서대로 조회
-     * 문제 순서는 id 순서로 보장됩니다.
+     * 특정 추천의 문제들을 삽입 순서대로 조회
      *
      * @param recommendationId 추천 ID
-     * @return 문제 목록 (id 순서로 정렬)
+     * @return 문제 목록 (삽입 순서)
      */
     @Query("SELECT rp FROM RecommendationProblem rp " +
             "WHERE rp.recommendation.id = :recommendationId " +

--- a/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailService.java
+++ b/src/main/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailService.java
@@ -9,14 +9,16 @@ import com.ryu.studyhelper.recommendation.domain.member.MemberRecommendation;
 import com.ryu.studyhelper.recommendation.dto.internal.BatchResult;
 import com.ryu.studyhelper.recommendation.mailbuilder.RecommendationMailBuilder;
 import com.ryu.studyhelper.recommendation.repository.MemberRecommendationRepository;
+import com.ryu.studyhelper.recommendation.repository.RecommendationProblemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 추천 이메일 발송
@@ -31,6 +33,7 @@ public class RecommendationEmailService {
     private final MailSender mailSender;
     private final RecommendationMailBuilder recommendationMailBuilder;
     private final MemberRecommendationRepository memberRecommendationRepository;
+    private final RecommendationProblemRepository recommendationProblemRepository;
 
     /**
      * 배치: PENDING 상태의 추천들에 대해 이메일 발송
@@ -43,11 +46,14 @@ public class RecommendationEmailService {
         List<MemberRecommendation> pendingRecommendations = memberRecommendationRepository
                 .findByRecommendationDateAndEmailSendStatus(missionDate, EmailSendStatus.PENDING);
 
+        Map<Long, List<Problem>> problemsByRecommendationId = loadProblemsByRecommendation(pendingRecommendations);
+
         int successCount = 0;
         int failCount = 0;
 
         for (MemberRecommendation mr : pendingRecommendations) {
-            if (sendEmail(mr)) {
+            List<Problem> problems = problemsByRecommendationId.get(mr.getRecommendation().getId());
+            if (sendEmail(mr, problems)) {
                 successCount++;
             } else {
                 failCount++;
@@ -71,6 +77,8 @@ public class RecommendationEmailService {
         List<MemberRecommendation> failedRecommendations = memberRecommendationRepository
                 .findByRecommendationDateAndEmailSendStatus(missionDate, EmailSendStatus.FAILED);
 
+        Map<Long, List<Problem>> problemsByRecommendationId = loadProblemsByRecommendation(failedRecommendations);
+
         int successCount = 0;
         int failCount = 0;
 
@@ -82,7 +90,8 @@ public class RecommendationEmailService {
                 continue;
             }
             mr.retryAsPending();
-            if (sendEmail(mr)) {
+            List<Problem> problems = problemsByRecommendationId.get(mr.getRecommendation().getId());
+            if (sendEmail(mr, problems)) {
                 successCount++;
             } else {
                 failCount++;
@@ -94,14 +103,15 @@ public class RecommendationEmailService {
         return new BatchResult(failedRecommendations.size(), successCount, 0, failCount);
     }
 
-    /**
-     * 배치 이메일 발송용 — mr에서 problems를 직접 추출 (JOIN FETCH로 로드된 경우에만 호출)
-     */
-    private boolean sendEmail(MemberRecommendation mr) {
-        List<Problem> problems = mr.getRecommendation().getProblems().stream()
-                .map(RecommendationProblem::getProblem)
-                .toList();
-        return sendEmail(mr, problems);
+    private Map<Long, List<Problem>> loadProblemsByRecommendation(List<MemberRecommendation> memberRecommendations) {
+        return memberRecommendations.stream()
+                .map(mr -> mr.getRecommendation().getId())
+                .distinct()
+                .collect(Collectors.toMap(
+                        id -> id,
+                        id -> recommendationProblemRepository.findByRecommendationIdOrderById(id)
+                                .stream().map(RecommendationProblem::getProblem).toList()
+                ));
     }
 
     /**

--- a/src/test/java/com/ryu/studyhelper/recommendation/repository/MemberRecommendationRepositoryTest.java
+++ b/src/test/java/com/ryu/studyhelper/recommendation/repository/MemberRecommendationRepositoryTest.java
@@ -1,0 +1,193 @@
+package com.ryu.studyhelper.recommendation.repository;
+
+import com.ryu.studyhelper.common.MissionCyclePolicy;
+import com.ryu.studyhelper.member.domain.Member;
+import com.ryu.studyhelper.member.repository.MemberRepository;
+import com.ryu.studyhelper.problem.domain.Problem;
+import com.ryu.studyhelper.problem.repository.ProblemRepository;
+import com.ryu.studyhelper.recommendation.domain.Recommendation;
+import com.ryu.studyhelper.recommendation.domain.RecommendationProblem;
+import com.ryu.studyhelper.recommendation.domain.RecommendationStatus;
+import com.ryu.studyhelper.recommendation.domain.RecommendationType;
+import com.ryu.studyhelper.recommendation.domain.member.EmailSendStatus;
+import com.ryu.studyhelper.recommendation.domain.member.MemberRecommendation;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("MemberRecommendationRepository 테스트")
+class MemberRecommendationRepositoryTest {
+
+    @Autowired
+    private Clock clock;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private RecommendationRepository recommendationRepository;
+
+    @Autowired
+    private RecommendationProblemRepository recommendationProblemRepository;
+
+    @Autowired
+    private MemberRecommendationRepository memberRecommendationRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private static final int MEMBER_COUNT = 10;
+    private static final int PROBLEM_COUNT = 3;
+
+    @BeforeEach
+    void setUp() {
+        memberRecommendationRepository.deleteAll();
+        recommendationProblemRepository.deleteAll();
+        recommendationRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("팀원 10명이 같은 Recommendation을 공유할 때 problems가 중복 누적되지 않아야 한다")
+    void problemsAreNotInflated_whenMembersShareSameRecommendation() {
+        // given
+        LocalDate missionDate = MissionCyclePolicy.getMissionDate(clock);
+        Recommendation recommendation = createRecommendation(missionDate);
+        createRecommendationProblems(recommendation, PROBLEM_COUNT);
+
+        for (int i = 1; i <= MEMBER_COUNT; i++) {
+            Member member = createMember("user" + i, "user" + i + "@test.com");
+            createMemberRecommendation(member, recommendation);
+        }
+
+        // 1차 캐시 초기화 — 쿼리 결과가 캐시 없이 직접 로딩되도록
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<MemberRecommendation> memberRecommendations = memberRecommendationRepository
+                .findByRecommendationDateAndEmailSendStatus(missionDate, EmailSendStatus.PENDING);
+
+        // then
+        assertThat(memberRecommendations).hasSize(MEMBER_COUNT);
+
+        memberRecommendations.forEach(mr -> {
+            int problemCount = mr.getRecommendation().getProblems().size();
+            System.out.printf("[DEBUG] 회원 %-10s → problems: %d개%n", mr.getMember().getHandle(), problemCount);
+            assertThat(mr.getRecommendation().getProblems())
+                    .as("회원 %s의 problems 수", mr.getMember().getHandle())
+                    .hasSize(PROBLEM_COUNT);
+        });
+    }
+
+    @Test
+    @DisplayName("1명에 대해 같은 쿼리를 10번 반복하면 problems가 10배 누적된다")
+    void problemsAreInflated_whenSameQueryRepeated() {
+        // given
+        LocalDate missionDate = MissionCyclePolicy.getMissionDate(clock);
+        Recommendation recommendation = createRecommendation(missionDate);
+        createRecommendationProblems(recommendation, PROBLEM_COUNT);
+        createMember("user1", "user1@test.com");
+        createMemberRecommendation(createMember("solo", "solo@test.com"), recommendation);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when: 같은 쿼리 10번 반복 (캐시 초기화 없이)
+        for (int i = 0; i < 10; i++) {
+            memberRecommendationRepository
+                    .findByRecommendationDateAndEmailSendStatus(missionDate, EmailSendStatus.PENDING);
+        }
+
+        List<MemberRecommendation> results = memberRecommendationRepository
+                .findByRecommendationDateAndEmailSendStatus(missionDate, EmailSendStatus.PENDING);
+
+        // then
+        results.forEach(mr -> {
+            int problemCount = mr.getRecommendation().getProblems().size();
+            System.out.printf("[DEBUG] 회원 %-10s → problems: %d개 (기대: %d개)%n",
+                    mr.getMember().getHandle(), problemCount, PROBLEM_COUNT);
+        });
+
+        results.forEach(mr ->
+                assertThat(mr.getRecommendation().getProblems())
+                        .as("반복 쿼리 후 회원 %s의 problems 수", mr.getMember().getHandle())
+                        .hasSize(PROBLEM_COUNT)
+        );
+    }
+
+    // === Helper Methods ===
+
+    private Recommendation createRecommendation(LocalDate date) {
+        return recommendationRepository.save(
+                Recommendation.builder()
+                        .teamId(1L)
+                        .squadId(1L)
+                        .type(RecommendationType.SCHEDULED)
+                        .date(date)
+                        .status(RecommendationStatus.SUCCESS)
+                        .build()
+        );
+    }
+
+    private void createRecommendationProblems(Recommendation recommendation, int count) {
+        for (int i = 1; i <= count; i++) {
+            final long problemId = 9000L + i;
+            Problem problem = problemRepository.findById(problemId)
+                    .orElseGet(() -> problemRepository.save(
+                            Problem.builder()
+                                    .id(problemId)
+                                    .title("Problem " + problemId)
+                                    .titleKo("문제 " + problemId)
+                                    .level(1)
+                                    .build()
+                    ));
+            recommendationProblemRepository.save(
+                    RecommendationProblem.builder()
+                            .recommendation(recommendation)
+                            .problem(problem)
+                            .build()
+            );
+        }
+    }
+
+    private Member createMember(String handle, String email) {
+        return memberRepository.save(
+                Member.builder()
+                        .handle(handle)
+                        .email(email)
+                        .provider("google")
+                        .providerId(handle + "_" + System.nanoTime())
+                        .build()
+        );
+    }
+
+    private MemberRecommendation createMemberRecommendation(Member member, Recommendation recommendation) {
+        return memberRecommendationRepository.save(
+                MemberRecommendation.builder()
+                        .member(member)
+                        .recommendation(recommendation)
+                        .teamId(1L)
+                        .squadId(1L)
+                        .teamName("테스트팀")
+                        .emailSendStatus(EmailSendStatus.PENDING)
+                        .build()
+        );
+    }
+}

--- a/src/test/java/com/ryu/studyhelper/recommendation/repository/MemberRecommendationRepositoryTest.java
+++ b/src/test/java/com/ryu/studyhelper/recommendation/repository/MemberRecommendationRepositoryTest.java
@@ -97,19 +97,18 @@ class MemberRecommendationRepositoryTest {
     }
 
     @Test
-    @DisplayName("1명에 대해 같은 쿼리를 10번 반복하면 problems가 10배 누적된다")
-    void problemsAreInflated_whenSameQueryRepeated() {
+    @DisplayName("1명에 대해 같은 쿼리를 10번 반복해도 problems는 누적되지 않는다")
+    void problemsAreNotInflated_whenSameQueryRepeatedForSingleMember() {
         // given
         LocalDate missionDate = MissionCyclePolicy.getMissionDate(clock);
         Recommendation recommendation = createRecommendation(missionDate);
         createRecommendationProblems(recommendation, PROBLEM_COUNT);
-        createMember("user1", "user1@test.com");
         createMemberRecommendation(createMember("solo", "solo@test.com"), recommendation);
 
         entityManager.flush();
         entityManager.clear();
 
-        // when: 같은 쿼리 10번 반복 (캐시 초기화 없이)
+        // when: 같은 쿼리 10번 반복 — 컬렉션이 한 번 초기화되면 이후 쿼리는 캐시를 재사용하므로 누적 없음
         for (int i = 0; i < 10; i++) {
             memberRecommendationRepository
                     .findByRecommendationDateAndEmailSendStatus(missionDate, EmailSendStatus.PENDING);

--- a/src/test/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailServiceTest.java
+++ b/src/test/java/com/ryu/studyhelper/recommendation/service/RecommendationEmailServiceTest.java
@@ -9,6 +9,7 @@ import com.ryu.studyhelper.recommendation.domain.member.EmailSendStatus;
 import com.ryu.studyhelper.recommendation.domain.member.MemberRecommendation;
 import com.ryu.studyhelper.recommendation.mailbuilder.RecommendationMailBuilder;
 import com.ryu.studyhelper.recommendation.repository.MemberRecommendationRepository;
+import com.ryu.studyhelper.recommendation.repository.RecommendationProblemRepository;
 import com.ryu.studyhelper.team.domain.Team;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,6 +46,9 @@ class RecommendationEmailServiceTest {
     @Mock
     private MemberRecommendationRepository memberRecommendationRepository;
 
+    @Mock
+    private RecommendationProblemRepository recommendationProblemRepository;
+
     @InjectMocks
     private RecommendationEmailService recommendationEmailService;
 
@@ -55,6 +59,7 @@ class RecommendationEmailServiceTest {
         Instant instant = ldt.atZone(ZONE_ID).toInstant();
         lenient().when(clock.instant()).thenReturn(instant);
         lenient().when(clock.getZone()).thenReturn(ZONE_ID);
+        lenient().when(recommendationProblemRepository.findByRecommendationIdOrderById(any())).thenReturn(List.of());
     }
 
     @Nested
@@ -201,6 +206,7 @@ class RecommendationEmailServiceTest {
         setFieldValue(team, "id", 1L);
 
         Recommendation recommendation = Recommendation.createPending(1L, 1L, RecommendationType.SCHEDULED, LocalDate.now());
+        setFieldValue(recommendation, "id", id);
 
         MemberRecommendation mr = MemberRecommendation.createForSquad(member, recommendation, team, 1L);
         setFieldValue(mr, "id", id);


### PR DESCRIPTION
- closes #216 
## 변경 사항

이메일 발송 배치에서 팀원 N명이 같은 Recommendation을 공유할 때 문제가 N배 중복 포함되는 버그 수정.

### 원인

`findByRecommendationDateAndEmailSendStatus` 쿼리에서 `r.problems`를 JOIN FETCH하면, 팀원 N명 × 문제 M개 = SQL N×M 행이 반환됨. Hibernate First-Level Cache로 인해 모든 `MemberRecommendation`이 같은 `Recommendation` 인스턴스를 공유하므로, `problems` 리스트에 문제가 N번 누적됨.

### 해결

| 파일 | 변경 내용 |
|------|----------|
| `MemberRecommendationRepository` | 이메일 배치 쿼리에서 `r.problems` JOIN FETCH 제거 |
| `RecommendationEmailService` | Recommendation별 problems 별도 조회 후 `sendEmail`에 직접 주입 |
| `MemberRecommendationRepositoryTest` | 버그 재현 및 회귀 방지 통합 테스트 추가 |
| `RecommendationEmailServiceTest` | `RecommendationProblemRepository` Mock 추가 |

### 부수 효과

기존 `getProblems()`(`@OneToMany`, `@OrderBy` 없음)에서 `findByRecommendationIdOrderById`(`ORDER BY rp.id ASC`)로 변경되어 문제 목록 순서가 삽입 순서로 명시적 보장됨.

## Test plan

- [x] `MemberRecommendationRepositoryTest` — 팀원 10명 × 문제 3개 시나리오 재현 및 통과
- [x] 전체 테스트 통과
- [ ] 배치 이메일 실제 발송 후 문제 목록 정상 확인

- Closes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 여러 사용자가 동일한 추천을 공유할 때 추천 문제 컬렉션이 중복되는 문제를 해결했습니다.
* **성능/동작 개선**
  * 추천 문제 조회 방식 및 이메일 전송 시 문제 조회 흐름을 개선하여 불필요한 중복 로드를 방지했습니다.
* **테스트**
  * 추천 문제 로딩 및 중복 여부를 검증하는 통합 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->