### PR TITLE
[REFACTOR] solved.ac HTTP/2 전환 - OkHttp 적용 (#218)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,10 @@ dependencies {
 
     // 액추에이터
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+//    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
-    // External HTTP client for synchronous calls
-    implementation 'org.apache.httpcomponents.client5:httpclient5'
+    // OkHttp - HTTP/2 지원 외부 API 클라이언트 (solved.ac Cloudflare 대응)
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 
     // Sentry - Error tracking and monitoring
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.18.0'

--- a/src/main/java/com/ryu/studyhelper/infrastructure/solvedac/client/SolvedAcRestClient.java
+++ b/src/main/java/com/ryu/studyhelper/infrastructure/solvedac/client/SolvedAcRestClient.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-@SuppressWarnings("deprecation") // OkHttp3ClientHttpRequestFactory: Spring 6.1 deprecated, Spring 7 제거 예정. JDK HttpClient는 Cloudflare TLS 지문(JA3) 차단으로 사용 불가.
 @Component
 public class SolvedAcRestClient implements SolvedAcHttpClient {
     private static final String DEFAULT_BASE_URL = "https://solved.ac/api/v3";
@@ -33,6 +32,7 @@ public class SolvedAcRestClient implements SolvedAcHttpClient {
                 .build();
     }
 
+    @SuppressWarnings("deprecation") // OkHttp3ClientHttpRequestFactory: Spring 6.1 deprecated, Spring 7 제거 예정. JDK HttpClient는 Cloudflare TLS 지문(JA3) 차단으로 사용 불가.
     private OkHttp3ClientHttpRequestFactory buildRequestFactory() {
         // OkHttp: HTTP/2 우선 협상(ALPN), HTTP/1.1 폴백, 커넥션 풀 자동 관리
         // Android/Chrome 유사 TLS 지문(JA3)으로 Cloudflare managed challenge 통과

--- a/src/main/java/com/ryu/studyhelper/infrastructure/solvedac/client/SolvedAcRestClient.java
+++ b/src/main/java/com/ryu/studyhelper/infrastructure/solvedac/client/SolvedAcRestClient.java
@@ -5,26 +5,23 @@ import com.ryu.studyhelper.infrastructure.solvedac.dto.ProblemSearchResponse;
 import com.ryu.studyhelper.infrastructure.solvedac.dto.SolvedAcUserResponse;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
-import org.apache.hc.client5.http.config.ConnectionConfig;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.core5.util.Timeout;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("deprecation") // OkHttp3ClientHttpRequestFactory: Spring 6.1 deprecated, Spring 7 제거 예정. JDK HttpClient는 Cloudflare TLS 지문(JA3) 차단으로 사용 불가.
 @Component
 public class SolvedAcRestClient implements SolvedAcHttpClient {
     private static final String DEFAULT_BASE_URL = "https://solved.ac/api/v3";
-    private static final int CONNECT_TIMEOUT_SECONDS = 3;            // TCP 연결 타임아웃
-    private static final int CONN_REQUEST_TIMEOUT_SECONDS = 30;     // 풀에서 커넥션 대기 타임아웃 (최후 안전망, 지연 감지는 서킷브레이커 담당)
-    private static final int RESPONSE_TIMEOUT_SECONDS = 30;         // 서버 응답 타임아웃 (최후 안전망, 지연 감지는 서킷브레이커 담당)
-    private static final int MAX_CONN_PER_ROUTE = 5;                // Apache HttpClient5 기본값
-    private static final int MAX_CONN_TOTAL = 25;                   // Apache HttpClient5 기본값
+    private static final int CONNECT_TIMEOUT_SECONDS = 3;       // TCP 연결 타임아웃
+    private static final int RESPONSE_TIMEOUT_SECONDS = 30;     // 서버 응답 타임아웃 (최후 안전망, 지연 감지는 서킷브레이커 담당)
 
     private final RestClient rest;
 
@@ -36,24 +33,16 @@ public class SolvedAcRestClient implements SolvedAcHttpClient {
                 .build();
     }
 
-    private HttpComponentsClientHttpRequestFactory buildRequestFactory() {
-        var connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
-                .setMaxConnPerRoute(MAX_CONN_PER_ROUTE)
-                .setMaxConnTotal(MAX_CONN_TOTAL)
-                .setDefaultConnectionConfig(ConnectionConfig.custom()
-                        .setConnectTimeout(Timeout.ofSeconds(CONNECT_TIMEOUT_SECONDS))
-                        .build())
+    private OkHttp3ClientHttpRequestFactory buildRequestFactory() {
+        // OkHttp: HTTP/2 우선 협상(ALPN), HTTP/1.1 폴백, 커넥션 풀 자동 관리
+        // Android/Chrome 유사 TLS 지문(JA3)으로 Cloudflare managed challenge 통과
+        var okHttpClient = new OkHttpClient.Builder()
+                .protocols(List.of(Protocol.HTTP_2, Protocol.HTTP_1_1))
+                .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .build();
 
-        var httpClient = HttpClients.custom()
-                .setConnectionManager(connectionManager)
-                .setDefaultRequestConfig(RequestConfig.custom()
-                        .setConnectionRequestTimeout(Timeout.ofSeconds(CONN_REQUEST_TIMEOUT_SECONDS))
-                        .setResponseTimeout(Timeout.ofSeconds(RESPONSE_TIMEOUT_SECONDS))
-                        .build())
-                .build();
-
-        return new HttpComponentsClientHttpRequestFactory(httpClient);
+        return new OkHttp3ClientHttpRequestFactory(okHttpClient);
     }
 
 


### PR DESCRIPTION
## 변경 사항

solved.ac가 비브라우저 TLS 지문(JA3)을 Cloudflare managed challenge로 차단함.

| 클라이언트 | HTTP 버전 | TLS 지문 | 결과 |
|---|---|---|---|
| Apache HttpClient 5 | http/1.1 | Java JSSE | 403 차단 |
| JDK HttpClient (HTTP/2) | h2 | Java JSSE | 403 차단 |
| **OkHttp** | **h2** | **Android/Chrome 유사** | **200 통과** |

- JDK HttpClient는 HTTP/2 협상은 성공하나 JSSE TLS 지문이 Cloudflare에 의해 차단됨
- OkHttp는 Android/Chrome과 유사한 TLS 지문(JA3)으로 Cloudflare 통과
- `httpclient5` 제거, `okhttp:4.12.0` 추가
- `OkHttp3ClientHttpRequestFactory` 기반으로 교체 (HTTP/2 우선, HTTP/1.1 폴백)

## 주의사항

- `OkHttp3ClientHttpRequestFactory`는 Spring 6.1 deprecated, Spring 7 제거 예정
- 현재 Spring Boot 3.2 기준 정상 동작 (`@SuppressWarnings("deprecation")` 처리)

- Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 더 효율적인 HTTP 클라이언트 라이브러리를 사용하여 통신 성능을 개선했습니다.
  * HTTP/2 프로토콜 지원을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->